### PR TITLE
edits

### DIFF
--- a/src/scripting/lexer.rs
+++ b/src/scripting/lexer.rs
@@ -33,8 +33,8 @@ impl Lexer {
                     }
                     let last_token = self.tokens.last().unwrap();
                     if !WHITESPACE_TOKENS
-                        .map(|x| x.to_string())
-                        .contains(&last_token.token_type.to_string())
+                        .map(|x| x)
+                        .contains(&last_token.token_type)
                     {
                         let start_position =
                             1 + self.context.position - last_token.value.len() as u64;
@@ -69,7 +69,7 @@ impl Lexer {
                     line: self.context.line,
                     value: matched_string.to_string(),
                 });
-                if token_regex.clone().to_string() == TokenType::ExpressionEnd.to_string() {
+                if token_regex.to_string() == TokenType::ExpressionEnd.to_string() {
                     self.context.line += 1;
                 };
                 self.context.position += matched_string.len() as u64;
@@ -101,10 +101,8 @@ impl Lexer {
             let current_token = self.tokens.last().unwrap();
             let last_token = self.tokens.get(self.tokens.len() - 2).unwrap();
 
-            let current_token_is_alphanumeric =
-                current_token.token_type.to_string() == TokenType::Alphanumeric.to_string();
-            let last_token_is_number =
-                last_token.token_type.to_string() == TokenType::Number.to_string();
+            let current_token_is_alphanumeric = current_token.token_type == TokenType::Alphanumeric;
+            let last_token_is_number = last_token.token_type == TokenType::Number;
             if last_token_is_number && current_token_is_alphanumeric {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
@@ -125,9 +123,7 @@ impl Lexer {
 
     fn throw_error_if_unresolved_chars_near_string(&mut self) -> io::Result<()> {
         let current_token = self.tokens.last().unwrap();
-        if !self.tokens.is_empty()
-            && current_token.token_type.to_string() == TokenType::CharArray.to_string()
-        {
+        if !self.tokens.is_empty() && current_token.token_type == TokenType::CharArray {
             let both_sides_unresolved_chars_regex = Regex::new(r"[\w\d]").unwrap();
             let left_side_unresolved_chars_regex = Regex::new(r"[\.]").unwrap();
 

--- a/src/scripting/parser.rs
+++ b/src/scripting/parser.rs
@@ -56,7 +56,7 @@ impl Parser {
 
         if expected_tokens
             .iter()
-            .any(|x| x.to_string() == current_token.token_type.to_string())
+            .any(|x| *x == current_token.token_type)
         {
             self.context.position += 1;
             return Some(current_token.clone());

--- a/src/scripting/tokens.rs
+++ b/src/scripting/tokens.rs
@@ -1,6 +1,6 @@
 use strum_macros::{Display, EnumIter};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Token {
     pub token_type: TokenType,
     pub position: u64,
@@ -8,7 +8,7 @@ pub struct Token {
     pub value: String,
 }
 
-#[derive(Debug, EnumIter, Display, Clone)]
+#[derive(Debug, EnumIter, Display, Clone, PartialEq)]
 pub enum TokenType {
     VariableAssignment,
     FunctionAssignment,

--- a/src/shell/handling.rs
+++ b/src/shell/handling.rs
@@ -12,7 +12,7 @@ pub fn handle_command_arguments() -> Result<()> {
             _ => {
                 eprintln!("Invalid arguments");
                 std::process::exit(1);
-            },
+            }
         }
     } else {
         print_help_section();


### PR DESCRIPTION
Сделал код лучше читаемым за счет удаление .to_string(), я бы ещё удалил
``` rust
let current_token_is_alphanumeric = current_token.token_type == TokenType::Alphanumeric;
let last_token_is_number = last_token.token_type == TokenType::Number;
```
сделал бы
``` rust
impl TokenType {
    pub fn is_type(&self, type: TokenType);
}
```
возможно так получится короче чем городить из == как минимум длинные название переменных можно будет убрать и просто при не обходимости обойтись коментариями что и как